### PR TITLE
Botania progression changes

### DIFF
--- a/scripts/Armor.zs
+++ b/scripts/Armor.zs
@@ -32,23 +32,32 @@ tc.addTableRecipe(<thermalfoundation:armor.legs_bronze>, <silentgems:armorframe:
 recipes.remove(<thermalfoundation:armor.boots_bronze>);
 tc.addTableRecipe(<thermalfoundation:armor.boots_bronze>, <silentgems:armorframe:3>, <liquid:bronze>, 576, true);
 
+recipes.remove(<botania:manasteelhelm>);
+tc.addTableRecipe(<botania:manasteelhelm>, <silentgems:armorframe:4>, <liquid:manasteel>, 720, true);
+recipes.remove(<botania:manasteelchest>);
+tc.addTableRecipe(<botania:manasteelchest>, <silentgems:armorframe:5>, <liquid:manasteel>, 1152, true);
+recipes.remove(<botania:manasteellegs>);
+tc.addTableRecipe(<botania:manasteellegs>, <silentgems:armorframe:6>, <liquid:manasteel>, 1008, true);
+recipes.remove(<botania:manasteelboots>);
+tc.addTableRecipe(<botania:manasteelboots>, <silentgems:armorframe:7>, <liquid:manasteel>, 576, true);
+
 recipes.remove(<abyssalcraft:ahelmet>);
-tc.addTableRecipe(<abyssalcraft:ahelmet>, <silentgems:armorframe>, <liquid:moltenabyssalnite>, 720, true);
+tc.addTableRecipe(<abyssalcraft:ahelmet>, <silentgems:armorframe:4>, <liquid:moltenabyssalnite>, 720, true);
 recipes.remove(<abyssalcraft:aplate>);
-tc.addTableRecipe(<abyssalcraft:aplate>, <silentgems:armorframe:1>, <liquid:moltenabyssalnite>, 1152, true);
+tc.addTableRecipe(<abyssalcraft:aplate>, <silentgems:armorframe:5>, <liquid:moltenabyssalnite>, 1152, true);
 recipes.remove(<abyssalcraft:alegs>);
-tc.addTableRecipe(<abyssalcraft:alegs>, <silentgems:armorframe:2>, <liquid:moltenabyssalnite>, 1008, true);
+tc.addTableRecipe(<abyssalcraft:alegs>, <silentgems:armorframe:6>, <liquid:moltenabyssalnite>, 1008, true);
 recipes.remove(<abyssalcraft:aboots>);
-tc.addTableRecipe(<abyssalcraft:aboots>, <silentgems:armorframe:3>, <liquid:moltenabyssalnite>, 576, true);
+tc.addTableRecipe(<abyssalcraft:aboots>, <silentgems:armorframe:7>, <liquid:moltenabyssalnite>, 576, true);
 
 recipes.remove(<abyssalcraft:corhelmet>);
-tc.addTableRecipe(<abyssalcraft:corhelmet>, <silentgems:armorframe>, <liquid:moltenrefinedcoralium>, 720, true);
+tc.addTableRecipe(<abyssalcraft:corhelmet>, <silentgems:armorframe:4>, <liquid:moltenrefinedcoralium>, 720, true);
 recipes.remove(<abyssalcraft:corplate>);
-tc.addTableRecipe(<abyssalcraft:corplate>, <silentgems:armorframe:1>, <liquid:moltenrefinedcoralium>, 1152, true);
+tc.addTableRecipe(<abyssalcraft:corplate>, <silentgems:armorframe:5>, <liquid:moltenrefinedcoralium>, 1152, true);
 recipes.remove(<abyssalcraft:corlegs>);
-tc.addTableRecipe(<abyssalcraft:corlegs>, <silentgems:armorframe:2>, <liquid:moltenrefinedcoralium>, 1008, true);
+tc.addTableRecipe(<abyssalcraft:corlegs>, <silentgems:armorframe:6>, <liquid:moltenrefinedcoralium>, 1008, true);
 recipes.remove(<abyssalcraft:corboots>);
-tc.addTableRecipe(<abyssalcraft:corboots>, <silentgems:armorframe:3>, <liquid:moltenrefinedcoralium>, 576, true);
+tc.addTableRecipe(<abyssalcraft:corboots>, <silentgems:armorframe:7>, <liquid:moltenrefinedcoralium>, 576, true);
 
 recipes.remove(<silentgems:craftingmaterial:25>);
 recipes.remove(<silentgems:craftingmaterial:26>);

--- a/scripts/Botania.zs
+++ b/scripts/Botania.zs
@@ -2,6 +2,8 @@ import crafttweaker.item.IItemStack;
 import crafttweaker.item.IIngredient;
 import crafttweaker.item.IItemDefinition;
 
+print("--------------------------Botania Start-------------------------");
+
 	#Floral Fertilizer
 var botDyes = <botania:dye>.definition;
 for i in 0 to 16 {
@@ -28,3 +30,82 @@ recipes.addShaped(<botania:specialflower>.withTag({type: "puredaisy"}), [
 	#Mystic Flower Ore Dictionary
 var botPlants = <botania:flower>.definition;
 for i in 0 to 16 {<ore:mysticPlant>.add(botPlants.makeStack(i));}
+
+	#Mana Spreader (remove gold)
+recipes.removeShaped(<botania:spreader>);
+recipes.addShaped(<botania:spreader>,
+	[[<botania:livingwood>, <botania:livingwood>, <botania:livingwood>],
+	[<botania:livingwood>, <botania:petal>, null],
+	[<botania:livingwood>, <botania:livingwood>, <botania:livingwood>]]);
+	
+	#Manasteel (from reinforced stone or dried bricks)
+mods.botania.ManaInfusion.addInfusion(<botania:manaresource>, <ore:ingotReinforcedStone>, 6000);
+
+	#Endoflame (remove and flag in JEI)
+mods.botania.Apothecary.removeRecipe("endoflame");
+<botania:specialflower>.withTag({type: "endoflame"}).addTooltip(format.red("DISABLED"));
+
+	#Hydroangeas (remove and flag in JEI)
+mods.botania.Apothecary.removeRecipe("hydroangeas");
+<botania:specialflower>.withTag({type: "hydroangeas"}).addTooltip(format.red("DISABLED"));
+
+	#Black Lotus (first mana)
+mods.skyresources.infusion.addRecipe(<botania:blacklotus>,
+	<minecraft:coal:1>*16, <botania:specialflower>.withTag({type: "puredaisy"}), 19);
+	
+	#Mana Tablet
+recipes.addShaped(<botania:manatablet>.withTag({mana:8000}),
+	[[<botania:livingrock>, <botania:livingrock>, <botania:livingrock>],
+	[<botania:livingrock>, <botania:blacklotus>, <botania:livingrock>],
+	[<botania:livingrock>, <botania:livingrock>, <botania:livingrock>]]);
+
+	#Dandelifeon (Tier 1 recipe with life infusion)
+mods.skyresources.infusion.addRecipe(<botania:specialflower>.withTag({type: "dandelifeon"}),
+	<botania:manabottle>, <minecraft:yellow_flower>, 19);
+	
+	#Gourmaryllis
+mods.skyresources.infusion.addRecipe(<botania:specialflower>.withTag({type: "gourmaryllis"}),
+	<botania:manabottle>, <minecraft:melon_block>, 19);
+	
+	#Rosa Arcana
+mods.skyresources.infusion.addRecipe(<botania:specialflower>.withTag({type: "arcanerose"}),
+	<botania:manabottle>, <minecraft:red_flower>, 19);
+	
+	#Mana Lens: Magnetizing
+recipes.removeShaped(<grapplemod:grapplinghook>, [[null, <minecraft:iron_pickaxe>], [<minecraft:lead>, null]]);
+recipes.addShaped(<grapplemod:grapplinghook>, [[null, <minecraft:stone_pickaxe>], [<minecraft:lead>, null]]);
+recipes.removeShapeless(<botania:lens:10>.withTag({}), [<botania:lens>, <minecraft:iron_ingot>, <minecraft:gold_ingot>]);
+recipes.addShapeless(<botania:lens:10>.withTag({}), [<botania:lens>, <grapplemod:grapplinghook>, <grapplemod:grapplinghook>]);
+
+	#Rod of the Lands
+mods.botania.ManaInfusion.addInfusion(<botania:dirtrod>, <extrautils2:compresseddirt>, 8000);
+
+	#Rod of the Seas
+mods.botania.ManaInfusion.addInfusion(<botania:waterrod>, <skyresources:waterextractor>, 8000);
+
+	#Hopperhock
+mods.skyresources.infusion.addRecipe(<botania:specialflower>.withTag({type: "hopperhock"}),
+	<minecraft:hopper> * 4, <botania:specialflower>.withTag({type: "puredaisy"}), 10);
+	
+	#Soujourner's Sash (not available until Tier 2)
+recipes.removeShaped(<botania:travelbelt>);
+recipes.addShaped(<botania:travelbelt>, [[<botania:rune:2>, <minecraft:leather>, <ore:ingotGold>], [<minecraft:leather>, null, <minecraft:leather>], [<botania:manaresource>, <minecraft:leather>, <botania:rune:3>]]);
+	
+	#Dreamwood (early for crafty crate, from Darklands Oak Wood)
+mods.botania.ManaInfusion.addInfusion(<botania:dreamwood>, <abyssalcraft:dltlog>, 15000);
+
+	#Mana Pylon (Tier 2B option)
+recipes.addShaped(<botania:pylon>, [[null, <minecraft:gold_ingot>, null], [<botania:manaresource>, <astralsorcery:itemrockcrystalsimple>, <botania:manaresource>], [null, <minecraft:gold_ingot>, null]]);
+
+	#Kekimurus (Gate behind ender air for now)
+mods.botania.Apothecary.removeRecipe("kekimurus");
+mods.botania.Apothecary.addRecipe("kekimurus", [<ore:petalWhite>, <ore:petalWhite>, <ore:petalOrange>, <ore:petalOrange>, <ore:petalBrown>, <ore:petalBrown>, <botania:rune:10>, <botania:manaresource:15>]);
+
+	#Slime in a Bottle
+recipes.removeShaped(<botania:slimebottle>);
+recipes.addShaped(<botania:slimebottle>, [[<botania:manaresource>, <botania:managlass>, <botania:manaresource>], [<botania:manaresource>, <ore:slimeball>, <botania:manaresource>], [null, <botania:manaresource>, null]]);
+
+	#Rune of Gluttony (for Munchdew)
+mods.botania.RuneAltar.addRecipe(<botania:rune:10>, [<ore:gemBlackDiamond>, <ore:gemBlackDiamond>, <ore:runeWinterB>, <ore:runeFireB>], 12000);
+
+print("--------------------------Botania End-------------------------");

--- a/scripts/Botania.zs
+++ b/scripts/Botania.zs
@@ -35,7 +35,7 @@ for i in 0 to 16 {<ore:mysticPlant>.add(botPlants.makeStack(i));}
 recipes.removeShaped(<botania:spreader>);
 recipes.addShaped(<botania:spreader>,
 	[[<botania:livingwood>, <botania:livingwood>, <botania:livingwood>],
-	[<botania:livingwood>, <botania:petal>, null],
+	[<botania:livingwood>, <botania:petal:*>, null],
 	[<botania:livingwood>, <botania:livingwood>, <botania:livingwood>]]);
 	
 	#Manasteel (from reinforced stone or dried bricks)


### PR DESCRIPTION
- disable endoflame and hydroangeas
- alternate recipes for mana spreader and manasteel
- recipe changes to support early managen from rosa arcana, gourmaryllis, dandelifeon
- easier rod of the lands for dirt/clay
- recipe changes for ring of magnetization, rod of the seas, manasteel tools and armor, soujourner's sash, crafty crate, mana pylon, slime in a bottle, hopperhock
- recipe change for munchdew to allow earlier tree farms
- kekimurus moved later in progression

See https://github.com/Vyraal1/Interaction/issues/49