### PR TITLE
Remove Duplicate Enchantments

### DIFF
--- a/config/cyclicmagic.cfg
+++ b/config/cyclicmagic.cfg
@@ -85,13 +85,13 @@ cyclicmagic {
         B:EmptyBeacon=true
 
         # Set false to delete - requires restart [default: true]
-        B:EnchantAutoSmelt=true
+        B:EnchantAutoSmelt=false
 
         # Set false to delete - requires restart [default: true]
         B:EnchantBeheading=true
 
         # Set false to delete - requires restart [default: true]
-        B:EnchantExcavation=true
+        B:EnchantExcavation=false
 
         # Set false to delete - requires restart [default: true]
         B:EnchantExpBoost=true
@@ -103,10 +103,10 @@ cyclicmagic {
         B:EnchantLifeLeech=true
 
         # Set false to delete - requires restart [default: true]
-        B:EnchantMagnet=true
+        B:EnchantMagnet=false
 
         # Set false to delete - requires restart [default: true]
-        B:EnchantMultishot=true
+        B:EnchantMultishot=false
 
         # Set false to delete - requires restart [default: true]
         B:EnchantQuickdraw=true


### PR DESCRIPTION
- disable Magnet (Cyclic) in favour of Magnetic (Random Things)
- disable AutoSmelt (Cyclic) in favour of Smelting (CoFH Core) and Scorching Heat (Astral Sorcery - very rare)
- disable Excavation (Cyclic) in favour of OreExcavation (OEIntegration)
- disable Multi-Shot (Cyclic) in favour of Multishot (CoFH Core)